### PR TITLE
add content type test

### DIFF
--- a/pkg/logging/console.go
+++ b/pkg/logging/console.go
@@ -9,13 +9,11 @@ import (
 )
 
 const (
-	PRIVATE_PREFIX string = "PRIVATE::"
-	PUBLIC_PREFIX  string = "PUBLIC::"
-)
+	PRIVATE_PREFIX = "PRIVATE::"
+	PUBLIC_PREFIX  = "PUBLIC::"
 
-const (
-	NORMAL_LOG int = 1
-	FATAL_LOG  int = 2
+	NORMAL_LOG = 1
+	FATAL_LOG  = 2
 )
 
 // Console logs a prefix, IP, and message all appeneded together to the console.

--- a/pkg/logging/file.go
+++ b/pkg/logging/file.go
@@ -4,13 +4,11 @@ package logging
 import "os"
 
 const (
-	PRIVATE_LOG_FOLDER string = "logs/private/"
-	PUBLIC_LOG_FOLDER  string = "logs/public/"
-)
+	PRIVATE_LOG_FOLDER = "logs/private/"
+	PUBLIC_LOG_FOLDER  = "logs/public/"
 
-const (
-	ERROR   string = "error.log"
-	WARNING string = "warning.log"
+	ERROR   = "error.log"
+	WARNING = "warning.log"
 )
 
 // File logs a given message to a log file

--- a/pkg/routing/content_types.go
+++ b/pkg/routing/content_types.go
@@ -4,6 +4,7 @@ package routing
 import (
 	"errors"
 	"path/filepath"
+	"strings"
 )
 
 // getContentType returns the http header safe content-type attribute for the
@@ -13,24 +14,27 @@ import (
 // BUG(george-e-shaw-iv) Does not cover the bulk of encountered content types on the web
 func GetContentType(path string) (string, error) {
 	var contentType string
-	fileType := filepath.Ext(path)
 
-	if fileType == "" {
-		return contentType, errors.New("Invalid path, contained no period-separated content-type")
+	path = filepath.Base(path)
+	ext := filepath.Ext(path)
+	fn := strings.TrimSuffix(path, ext)
+
+	if ext == "" || fn == "" {
+		return "", errors.New("Invalid file path")
 	}
 
-	switch fileType {
-	case "html":
+	switch ext {
+	case ".html":
 		contentType = "text/html"
-	case "css":
+	case ".css":
 		contentType = "text/css"
-	case "js":
+	case ".js":
 		contentType = "text/javascript"
-	case "png":
+	case ".png":
 		contentType = "image/png"
-	case "jpg":
+	case ".jpg":
 		fallthrough
-	case "jpeg":
+	case ".jpeg":
 		contentType = "image/jpeg"
 	default:
 		contentType = "text/plain"

--- a/pkg/routing/content_types.go
+++ b/pkg/routing/content_types.go
@@ -3,17 +3,16 @@ package routing
 
 import (
 	"errors"
+	"mime"
 	"path/filepath"
 	"strings"
 )
 
-// getContentType returns the http header safe content-type attribute for the
-// requested path. If the requested path is not formatted correctly with an extension
+// getContentType returns the http header safe Content-Type for the requested
+// path. If the requested path is not formatted correctly with an extension
 // then the function will return the zero-value for a string and an error.
-// BUG(george-e-shaw-iv) Cannot handle interpreted files such as .php files
-// BUG(george-e-shaw-iv) Does not cover the bulk of encountered content types on the web
 func GetContentType(path string) (string, error) {
-	var contentType string
+	var ct string
 
 	path = filepath.Base(path)
 	ext := filepath.Ext(path)
@@ -23,22 +22,11 @@ func GetContentType(path string) (string, error) {
 		return "", errors.New("Invalid file path")
 	}
 
-	switch ext {
-	case ".html":
-		contentType = "text/html"
-	case ".css":
-		contentType = "text/css"
-	case ".js":
-		contentType = "text/javascript"
-	case ".png":
-		contentType = "image/png"
-	case ".jpg":
-		fallthrough
-	case ".jpeg":
-		contentType = "image/jpeg"
-	default:
-		contentType = "text/plain"
+	ct = mime.TypeByExtension(ext)
+
+	if ct == "" {
+		return "", errors.New("Could not get content type")
 	}
 
-	return contentType, nil
+	return ct, nil
 }

--- a/pkg/routing/content_types_test.go
+++ b/pkg/routing/content_types_test.go
@@ -7,29 +7,28 @@ import (
 func TestContentType(t *testing.T) {
 	cases := []struct {
 		input string
-		mime  string
 		ok    bool
 	}{
-		{"/path/to/index.html", "text/html", true},
-		{"somepath/file.css", "text/css", true},
-		{"test.js", "text/javascript", true},
-		{"asdf.png", "image/png", true},
-		{"asdfpng", "", false},
-		{"/something.jpg", "image/jpeg", true},
-		{"/something.jpeg", "image/jpeg", true},
-		{"this/should/fail/.png", "", false},
+		{"/path/to/index.html", true},
+		{"somepath/file.css", true},
+		{"test.js", true},
+		{"./relative/asdf.png", true},
+		{"/something.jpg", true},
+		{"/something.jpeg", true},
+		{"doc.pdf", true},
+		{"this/should/fail/.png", false},
+		{"php/doesnt/have/a/contenttype.php", false},
+		{".pdf", false},
+		{"asdfpng", false},
 	}
 
 	for _, tc := range cases {
 		mime, err := GetContentType(tc.input)
 		if err != nil && tc.ok == true {
-			t.Fatalf("\nGetContentType(%s): Got an error, expected OK.", tc.input)
+			t.Fatalf("\nGetContentType(%s): Expected OK, got error: %s", tc.input, err)
 		}
 		if err == nil && tc.ok == false {
-			t.Fatalf("\nGetContentType(%s): Expected error, got: %s", tc.input, tc.mime)
-		}
-		if mime != tc.mime {
-			t.Fatalf("\nGetContentType(%s):\nWant: %s\nGot: %s", tc.input, tc.mime, mime)
+			t.Fatalf("\nGetContentType(%s): Expected error, got OK: %s", tc.input, mime)
 		}
 	}
 

--- a/pkg/routing/content_types_test.go
+++ b/pkg/routing/content_types_test.go
@@ -1,0 +1,36 @@
+package routing
+
+import (
+	"testing"
+)
+
+func TestContentType(t *testing.T) {
+	cases := []struct {
+		input string
+		mime  string
+		ok    bool
+	}{
+		{"/path/to/index.html", "text/html", true},
+		{"somepath/file.css", "text/css", true},
+		{"test.js", "text/javascript", true},
+		{"asdf.png", "image/png", true},
+		{"asdfpng", "", false},
+		{"/something.jpg", "image/jpeg", true},
+		{"/something.jpeg", "image/jpeg", true},
+		{"this/should/fail/.png", "", false},
+	}
+
+	for _, tc := range cases {
+		mime, err := GetContentType(tc.input)
+		if err != nil && tc.ok == true {
+			t.Fatalf("\nGetContentType(%s): Got an error, expected OK.", tc.input)
+		}
+		if err == nil && tc.ok == false {
+			t.Fatalf("\nGetContentType(%s): Expected error, got: %s", tc.input, tc.mime)
+		}
+		if mime != tc.mime {
+			t.Fatalf("\nGetContentType(%s):\nWant: %s\nGot: %s", tc.input, tc.mime, mime)
+		}
+	}
+
+}


### PR DESCRIPTION
also includes some really small changes to 2 other files.

NOTE: You should definitely check out [the mime package](https://golang.org/pkg/mime/#TypeByExtension), it has this sort of functionality already. However, these mime types may not be what you're looking for. I can't quite tell.

When I tried rewriting this function to use `mime.TypeByExtension`, I ran into this error in my tests:
```
Want: text/html
Got: text/html; charset=utf-8
```

So I undid my changes. Let me know what your goal is with this function and we can find a better way.